### PR TITLE
Fixed Unit forge requirements in the tech tree

### DIFF
--- a/src/psammos/content/PsammosTechTree.java
+++ b/src/psammos/content/PsammosTechTree.java
@@ -163,11 +163,11 @@ public class PsammosTechTree {
 
             });
 
-            node(specialistUnitForge, Seq.with(new OnSector(ancientSwamp)), ()->{
+            node(specialistUnitForge, Seq.with(new OnSector(driedRiver)), ()->{
                 node(fang, ()->{
 
                 });
-                node(assaultUnitForge, ()->{
+                node(assaultUnitForge, Seq.with(new OnSector(ancientSwamp)), ()->{
                     node(tip, ()->{
 
                     });


### PR DESCRIPTION
specialist changed from onSector (Ancient Swamp) to onSector (DriedRiver)
assault changed from none to capture ancient swamp i think